### PR TITLE
Add CFFI alternative to ctypes

### DIFF
--- a/NativeImaging/backends/GraphicsMagick.py
+++ b/NativeImaging/backends/GraphicsMagick.py
@@ -5,8 +5,6 @@ An Image-compatible backend using GraphicsMagick
 
 from copy import deepcopy
 
-import ctypes
-
 from NativeImaging.api import Image
 
 try:
@@ -119,11 +117,9 @@ class GraphicsMagickImage(Image):
         if isinstance(fp, basestring):
             wand.MagickWriteImage(self._wand, fp)
         elif isinstance(fp, file):
-            c_file = ctypes.pythonapi.PyFile_AsFile(fp)
             wand.MagickWriteImageFile(self._wand, fp)
         elif hasattr(fp, "write"):
-            length = ctypes.c_size_t()
-            data = wand.MagickWriteImageBlob(self._wand, ctypes.pointer(length))
-            fp.write(data[0:length.value])
+            data = wand.MagickWriteImageBlob(self._wand)
+            fp.write(data)
         else:
             raise ValueError("Don't know how to write to a %r" % fp)

--- a/NativeImaging/backends/GraphicsMagick.py
+++ b/NativeImaging/backends/GraphicsMagick.py
@@ -9,7 +9,10 @@ import ctypes
 
 from NativeImaging.api import Image
 
-import wand_wrapper as wand
+try:
+    import wand_wrapper_cffi as wand
+except ImportError:
+    import wand_wrapper as wand
 
 
 class GraphicsMagickImage(Image):

--- a/NativeImaging/backends/GraphicsMagick.py
+++ b/NativeImaging/backends/GraphicsMagick.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-An Image-compatible backend using GraphicsMagick via ctypes
+An Image-compatible backend using GraphicsMagick
 """
 
 from copy import deepcopy
@@ -37,6 +37,7 @@ class GraphicsMagickImage(Image):
     def open(cls, fp, mode="rb"):
         i = cls()
 
+        # TODO: move magic argument handling into the backend library so e.g. cffi's FILE* works
         if isinstance(fp, basestring):
             wand.MagickReadImage(i._wand, fp)
         elif isinstance(fp, file):
@@ -121,9 +122,10 @@ class GraphicsMagickImage(Image):
         if isinstance(fp, basestring):
             wand.MagickWriteImage(self._wand, fp)
         elif isinstance(fp, file):
-            c_file = ctypes.pythonapi.PyFile_AsFile(fp)
-            wand.MagickWriteImageFile(self._wand, c_file)
+            # c_file = ctypes.pythonapi.PyFile_AsFile(fp)
+            wand.MagickWriteImageFile(self._wand, fp)
         elif hasattr(fp, "write"):
+            raise NotImplementedError
             length = ctypes.c_size_t()
             data = wand.MagickWriteImageBlob(self._wand, ctypes.pointer(length))
             fp.write(data[0:length.value])

--- a/NativeImaging/backends/GraphicsMagick.py
+++ b/NativeImaging/backends/GraphicsMagick.py
@@ -37,15 +37,12 @@ class GraphicsMagickImage(Image):
     def open(cls, fp, mode="rb"):
         i = cls()
 
-        # TODO: move magic argument handling into the backend library so e.g. cffi's FILE* works
         if isinstance(fp, basestring):
             wand.MagickReadImage(i._wand, fp)
         elif isinstance(fp, file):
-            i._c_file = c_file = ctypes.pythonapi.PyFile_AsFile(fp)
-            wand.MagickReadImageFile(i._wand, c_file)
+            wand.MagickReadImageFile(i._wand, fp)
         elif hasattr(fp, "read"):
-            b = ctypes.create_string_buffer(fp.read())
-            wand.MagickReadImageBlob(i._wand, b, ctypes.sizeof(b))
+            wand.MagickReadImageBlob(i._wand, fp.read())
         else:
             raise IOError("Cannot open %r object" % fp)
 
@@ -122,10 +119,9 @@ class GraphicsMagickImage(Image):
         if isinstance(fp, basestring):
             wand.MagickWriteImage(self._wand, fp)
         elif isinstance(fp, file):
-            # c_file = ctypes.pythonapi.PyFile_AsFile(fp)
+            c_file = ctypes.pythonapi.PyFile_AsFile(fp)
             wand.MagickWriteImageFile(self._wand, fp)
         elif hasattr(fp, "write"):
-            raise NotImplementedError
             length = ctypes.c_size_t()
             data = wand.MagickWriteImageBlob(self._wand, ctypes.pointer(length))
             fp.write(data[0:length.value])

--- a/NativeImaging/backends/wand_wrapper.py
+++ b/NativeImaging/backends/wand_wrapper.py
@@ -103,15 +103,27 @@ MagickStripImage.argtypes = [WAND_P]
 MagickStripImage.restype = MagickBooleanType
 MagickStripImage.errcheck = _wand_errcheck
 
-MagickReadImageBlob = _wandlib.MagickReadImageBlob
-MagickReadImageBlob.restype = MagickBooleanType
-MagickReadImageBlob.argtypes = [WAND_P, ctypes.c_void_p, ctypes.c_size_t]
-MagickReadImageBlob.errcheck = _wand_errcheck
+# The file I/O functions are complicated by the need to convert Python-like
+# files into something compatible with ctypes or CFFI:
+_MagickReadImageBlob = _wandlib.MagickReadImageBlob
+_MagickReadImageBlob.restype = MagickBooleanType
+_MagickReadImageBlob.argtypes = [WAND_P, ctypes.c_void_p, ctypes.c_size_t]
+_MagickReadImageBlob.errcheck = _wand_errcheck
 
-MagickReadImageFile = _wandlib.MagickReadImageFile
-MagickReadImageFile.restype = MagickBooleanType
-MagickReadImageFile.argtypes = [WAND_P, FILE_P]
-MagickReadImageFile.errcheck = _wand_errcheck
+
+def MagickReadImageBlob(wand, blob):
+    b = ctypes.create_string_buffer(blob)
+    return _MagickReadImageBlob(wand, b, ctypes.sizeof(b))
+
+_MagickReadImageFile = _wandlib.MagickReadImageFile
+_MagickReadImageFile.restype = MagickBooleanType
+_MagickReadImageFile.argtypes = [WAND_P, FILE_P]
+_MagickReadImageFile.errcheck = _wand_errcheck
+
+
+def MagickReadImageFile(wand, fp):
+    c_file = ctypes.pythonapi.PyFile_AsFile(fp)
+    return _MagickReadImageFile(wand, c_file)
 
 MagickReadImage = _wandlib.MagickReadImage
 MagickReadImage.restype = MagickBooleanType

--- a/NativeImaging/backends/wand_wrapper.py
+++ b/NativeImaging/backends/wand_wrapper.py
@@ -125,6 +125,32 @@ def MagickReadImageFile(wand, fp):
     c_file = ctypes.pythonapi.PyFile_AsFile(fp)
     return _MagickReadImageFile(wand, c_file)
 
+MagickWriteImage = _wandlib.MagickWriteImage
+MagickWriteImage.restype = MagickBooleanType
+MagickWriteImage.argtypes = [WAND_P, ctypes.c_char_p]
+MagickWriteImage.errcheck = _wand_errcheck
+
+_MagickWriteImageBlob = _wandlib.MagickWriteImageBlob
+_MagickWriteImageBlob.restype = ctypes.POINTER(ctypes.c_char)
+_MagickWriteImageBlob.argtypes = [WAND_P, ctypes.POINTER(ctypes.c_size_t)]
+_MagickWriteImageBlob.errcheck = _wand_errcheck
+
+
+def MagickWriteImageBlob(wand):
+    length = ctypes.c_size_t()
+    data = _MagickWriteImageBlob(wand, ctypes.pointer(length))
+    return data[0:length.value]
+
+_MagickWriteImageFile = _wandlib.MagickWriteImageFile
+_MagickWriteImageFile.restype = MagickBooleanType
+_MagickWriteImageFile.argtypes = [WAND_P, FILE_P]
+_MagickWriteImageFile.errcheck = _wand_errcheck
+
+
+def MagickWriteImageFile(wand, fp):
+    c_file = ctypes.pythonapi.PyFile_AsFile(fp)
+    _MagickWriteImageFile(wand, c_file)
+
 MagickReadImage = _wandlib.MagickReadImage
 MagickReadImage.restype = MagickBooleanType
 MagickReadImage.argtypes = [WAND_P, ctypes.c_char_p]
@@ -154,21 +180,6 @@ MagickSetCompressionQuality = _wandlib.MagickSetCompressionQuality
 MagickSetCompressionQuality.restype = MagickBooleanType
 MagickSetCompressionQuality.argtypes = [WAND_P, ctypes.c_ulong]
 MagickSetCompressionQuality.errcheck = _wand_errcheck
-
-MagickWriteImage = _wandlib.MagickWriteImage
-MagickWriteImage.restype = MagickBooleanType
-MagickWriteImage.argtypes = [WAND_P, ctypes.c_char_p]
-MagickWriteImage.errcheck = _wand_errcheck
-
-MagickWriteImageBlob = _wandlib.MagickWriteImageBlob
-MagickWriteImageBlob.restype = ctypes.POINTER(ctypes.c_char)
-MagickWriteImageBlob.argtypes = [WAND_P, ctypes.POINTER(ctypes.c_size_t)]
-MagickWriteImageBlob.errcheck = _wand_errcheck
-
-MagickWriteImageFile = _wandlib.MagickWriteImageFile
-MagickWriteImageFile.restype = MagickBooleanType
-MagickWriteImageFile.argtypes = [WAND_P, FILE_P]
-MagickWriteImageFile.errcheck = _wand_errcheck
 
 MagickScaleImage = _wandlib.MagickScaleImage
 MagickScaleImage.restype = MagickBooleanType

--- a/NativeImaging/backends/wand_wrapper_cffi.py
+++ b/NativeImaging/backends/wand_wrapper_cffi.py
@@ -1,0 +1,109 @@
+# encoding: utf-8
+"""
+cffi wrappers for GraphicsMagick functions with error-handling
+
+n.b. Heavy consultation of http://www.graphicsmagick.org/wand/magick_wand.html
+and the cffi documentation is advised
+"""
+
+import sys
+
+from cffi import FFI
+
+ffi = FFI()
+
+
+class WandException(Exception):
+    pass
+
+
+def _wand_errcheck(rc, func, args):
+    """
+    Intended for use as a ctypes errcheck function
+
+    Can only be used with functions which take Wand as their first argument
+    """
+
+    if not rc:
+        err_type = ffi.new("int", 0)
+        description = wand.MagickGetException(args[0], err_type)
+
+        if err_type.value == 430:  # "Unable to open file"
+            raise IOError(description)
+        else:
+            raise WandException(description)
+    else:
+        return rc
+
+
+ffi.cdef("""
+    struct _MagickWand { ...; };
+
+    typedef struct _MagickWand MagickWand;
+    typedef enum { ... } ExceptionType;
+    typedef enum { ... } FilterTypes;
+
+    char *MagickGetException( const MagickWand *wand, ExceptionType *severity );
+
+    MagickWand NewMagickWand( void );
+    MagickWand *CloneMagickWand( const MagickWand *wand );
+    void DestroyMagickWand( MagickWand *wand );
+
+    unsigned int MagickStripImage( MagickWand *wand );
+
+    unsigned int MagickReadImage( MagickWand *wand, const char *filename );
+    unsigned int MagickReadImageBlob( MagickWand *wand, const unsigned char *blob, const size_t length );
+    unsigned int MagickReadImageFile( MagickWand *wand, FILE *file );
+
+    unsigned long MagickGetImageHeight( MagickWand *wand );
+    unsigned long MagickGetImageWidth( MagickWand *wand );
+
+    const char *MagickGetImageFormat( MagickWand *wand );
+    unsigned int MagickSetImageFormat( MagickWand *wand, const char *format );
+
+    unsigned int MagickWriteImage( MagickWand *wand, const char *filename );
+    unsigned int MagickWriteImagesFile( MagickWand *wand, FILE *file, const unsigned int adjoin );
+    unsigned char *MagickWriteImageBlob( MagickWand *wand, size_t *length );
+    unsigned int MagickWriteImageFile( MagickWand *wand, FILE *file );
+
+    unsigned int MagickScaleImage( MagickWand *wand, const unsigned long columns, const unsigned long rows );
+    unsigned int MagickResizeImage( MagickWand *wand, const unsigned long columns,
+                                    const unsigned long rows, const FilterTypes filter,
+                                    const double blur );
+    unsigned int MagickCropImage( MagickWand *wand, const unsigned long width,
+                                  const unsigned long height, const long x, const long y );
+""")
+
+
+def pkgconfig(*packages, **kw):
+    # See http://code.activestate.com/recipes/502261-python-distutils-pkg-config/
+    from subprocess import check_output
+
+    flag_map = {'-I': 'include_dirs',
+                '-L': 'library_dirs',
+                '-l': 'libraries'}
+
+    cmd = ["pkg-config", "--libs", "--cflags"]
+    cmd.extend(packages)
+
+    for token in check_output(cmd).split():
+        flag = token[:2]
+        if flag in flag_map:
+            kw.setdefault(flag_map.get(flag), []).append(token[2:])
+        else:
+            # throw others to extra_link_args
+            kw.setdefault('extra_link_args', []).append(token)
+
+    # Remove duplicates:
+    for k, v in kw.iteritems():
+        kw[k] = list(set(v))
+
+    return kw
+
+wand = ffi.verify("""
+#include <wand/magick_wand.h>
+""", **pkgconfig('GraphicsMagickWand'))
+
+# FIXME: update _wand_errcheck to decorate wand.* for functions in cdefs
+
+wand.InitializeMagick(sys.argv[0])

--- a/NativeImaging/backends/wand_wrapper_cffi.py
+++ b/NativeImaging/backends/wand_wrapper_cffi.py
@@ -36,6 +36,7 @@ def check_rc(f):
             return rc
     return inner
 
+
 def returns_string(f):
     """Decorator which ensures that char* objects return simply Python strings"""
 
@@ -125,7 +126,13 @@ CloneMagickWand = check_rc(_wand.CloneMagickWand)
 MagickStripImage = check_rc(_wand.MagickStripImage)
 
 MagickReadImage = check_rc(_wand.MagickReadImage)
-MagickReadImageBlob = check_rc(_wand.MagickReadImageBlob)
+
+
+@check_rc
+def MagickReadImageBlob(wand, blob):
+    b = ffi.new("unsigned char[]", blob)
+    return _wand.MagickReadImageBlob(wand, b, ffi.sizeof(b))
+
 MagickReadImageFile = check_rc(_wand.MagickReadImageFile)
 
 MagickSetImageFormat = check_rc(_wand.MagickSetImageFormat)

--- a/NativeImaging/backends/wand_wrapper_cffi.py
+++ b/NativeImaging/backends/wand_wrapper_cffi.py
@@ -70,6 +70,7 @@ ffi.cdef("""
 
     const char *MagickGetImageFormat( MagickWand *wand );
     unsigned int MagickSetImageFormat( MagickWand *wand, const char *format );
+    unsigned int MagickSetCompressionQuality( MagickWand *wand, const unsigned long quality );
 
     unsigned int MagickWriteImage( MagickWand *wand, const char *filename );
     unsigned int MagickWriteImagesFile( MagickWand *wand, FILE *file, const unsigned int adjoin );
@@ -128,6 +129,7 @@ MagickReadImageBlob = check_rc(_wand.MagickReadImageBlob)
 MagickReadImageFile = check_rc(_wand.MagickReadImageFile)
 
 MagickSetImageFormat = check_rc(_wand.MagickSetImageFormat)
+MagickSetCompressionQuality = check_rc(_wand.MagickSetCompressionQuality)
 
 MagickWriteImage = check_rc(_wand.MagickWriteImage)
 MagickWriteImagesFile = check_rc(_wand.MagickWriteImagesFile)

--- a/NativeImaging/backends/wand_wrapper_cffi.py
+++ b/NativeImaging/backends/wand_wrapper_cffi.py
@@ -127,20 +127,23 @@ MagickStripImage = check_rc(_wand.MagickStripImage)
 
 MagickReadImage = check_rc(_wand.MagickReadImage)
 
+# The file I/O functions are complicated by the need to convert Python-like
+# files into something compatible with ctypes or CFFI:
 
 @check_rc
 def MagickReadImageBlob(wand, blob):
+    # TODO: figure out how to get a buffer view of a string and pass that directly:
     b = ffi.new("unsigned char[]", blob)
     return _wand.MagickReadImageBlob(wand, b, ffi.sizeof(b))
 
 MagickReadImageFile = check_rc(_wand.MagickReadImageFile)
 
-MagickSetImageFormat = check_rc(_wand.MagickSetImageFormat)
-MagickSetCompressionQuality = check_rc(_wand.MagickSetCompressionQuality)
-
 MagickWriteImage = check_rc(_wand.MagickWriteImage)
 MagickWriteImagesFile = check_rc(_wand.MagickWriteImagesFile)
 MagickWriteImageFile = check_rc(_wand.MagickWriteImageFile)
+
+MagickSetImageFormat = check_rc(_wand.MagickSetImageFormat)
+MagickSetCompressionQuality = check_rc(_wand.MagickSetCompressionQuality)
 
 MagickScaleImage = check_rc(_wand.MagickScaleImage)
 MagickResizeImage = check_rc(_wand.MagickResizeImage)

--- a/NativeImaging/backends/wand_wrapper_cffi.py
+++ b/NativeImaging/backends/wand_wrapper_cffi.py
@@ -28,9 +28,7 @@ def check_rc(f):
             desc_cdata = _wand.MagickGetException(args[0], err_type)
             description = ffi.string(desc_cdata)
 
-            print err_type[0], description
-
-            if err_type[0] == '#430':  # "Unable to open file"
+            if err_type[0] == 430:  # "Unable to open file"
                 raise IOError(description)
             else:
                 raise WandException(description)


### PR DESCRIPTION
Further optimization is still possible but this allows us to move over
to CFFI which will hopefully prove faster and is definitely easier to
keep in sync with the upstream C API
